### PR TITLE
Minor fixes

### DIFF
--- a/woocommerceconnector/sync_orders.py
+++ b/woocommerceconnector/sync_orders.py
@@ -34,7 +34,7 @@ def sync_woocommerce_orders():
                         make_woocommerce_log(status="Error", method="sync_woocommerce_orders", message=frappe.get_traceback(),
                             request_data=woocommerce_order, exception=True)
                     except Exception as e:
-                        if e.args and e.args[0] and e.args[0].decode("utf-8").startswith("402"):
+                        if e.args and e.args[0] and e.args[0].startswith("402"):
                             raise e
                         else:
                             make_woocommerce_log(title=e.message, status="Error", method="sync_woocommerce_orders", message=frappe.get_traceback(),

--- a/woocommerceconnector/sync_products.py
+++ b/woocommerceconnector/sync_products.py
@@ -628,6 +628,10 @@ def get_variant_attributes(item, price_list, warehouse):
 def get_price_and_stock_details(item, warehouse, price_list):
     actual_qty = frappe.db.get_value("Bin", {"item_code":item.get("item_code"), "warehouse": warehouse}, "actual_qty")
     reserved_qty = frappe.db.get_value("Bin", {"item_code":item.get("item_code"), "warehouse": warehouse}, "reserved_qty")
+    if actual_qty is None:
+        actual_qty = 0
+    if reserved_qty is None:
+        reserved_qty = 0
     qty = actual_qty - reserved_qty
     price = frappe.db.get_value("Item Price", \
             {"price_list": price_list, "item_code":item.get("item_code")}, "price_list_rate")
@@ -753,6 +757,10 @@ def update_item_stock(item_code, woocommerce_settings, bin=None, force=False):
 
                 actual_qty = bin.actual_qty
                 reserved_qty = bin.reserved_qty
+		if actual_qty is None:
+                    actual_qty = 0
+                if reserved_qty is None:
+                    reserved_qty = 0
                 qty = actual_qty - reserved_qty
 
                 for warehouse in woocommerce_settings.warehouses:


### PR DESCRIPTION
On sync_orders:
.decode("utf-8") is no longer needed

On sync_products, there is this error when there are no stocks setted up, will validate if any of those are None
qty = actual_qty - reserved_qty
TypeError: unsupported operand type(s) for -: 'NoneType' and 'NoneType'