### PR TITLE
Add support for default tax and shipping accounts

### DIFF
--- a/woocommerceconnector/woocommerceconnector/doctype/woocommerce_config/woocommerce_config.json
+++ b/woocommerceconnector/woocommerceconnector/doctype/woocommerce_config/woocommerce_config.json
@@ -48,6 +48,8 @@
   "section_break_31",
   "html_16",
   "taxes",
+  "default_tax_account",
+  "default_shipping_account",
   "section_tax_rules",
   "tax_rules",
   "section_break_25",
@@ -284,6 +286,20 @@
    "fieldtype": "Table",
    "label": "woocommerce Tax Account",
    "options": "woocommerce Tax Account"
+  },
+  {
+    "fieldname": "default_tax_account", 
+    "fieldtype": "Link", 
+    "label": "Default Tax Account", 
+    "options": "Account", 
+    "reqd": 1
+  },
+  {
+    "fieldname": "default_shipping_account", 
+    "fieldtype": "Link", 
+    "label": "Default Shipping Account", 
+    "options": "Account", 
+    "reqd": 1
   },
   {
    "fieldname": "section_tax_rules",

--- a/woocommerceconnector/woocommerceconnector/doctype/woocommerce_config/woocommerce_config.json
+++ b/woocommerceconnector/woocommerceconnector/doctype/woocommerce_config/woocommerce_config.json
@@ -291,15 +291,13 @@
     "fieldname": "default_tax_account", 
     "fieldtype": "Link", 
     "label": "Default Tax Account", 
-    "options": "Account", 
-    "reqd": 1
+    "options": "Account"
   },
   {
     "fieldname": "default_shipping_account", 
     "fieldtype": "Link", 
     "label": "Default Shipping Account", 
-    "options": "Account", 
-    "reqd": 1
+    "options": "Account"
   },
   {
    "fieldname": "section_tax_rules",


### PR DESCRIPTION
This allows for use of the TaxJar addon to calculate taxes.  The way it works is to put taxes into the orders with the id of 999999999.  This tax id is not found when requested.  The current code then crashes because it tries to get the tax account on an empty return.

This pull request adds two fields to the config: default_tax_account and default_shipping_account.  It then uses this if it can't find an actual account from the tax account list.  If these are not set in the config then the behavior is the same as the current code.